### PR TITLE
 Adds transitive dependencies (TypeScript v2) 

### DIFF
--- a/src/package.ts
+++ b/src/package.ts
@@ -3,31 +3,48 @@ import { maxSatisfying } from 'semver';
 import got from 'got';
 import { NPMPackage } from './types';
 
+type Package = { version: string; dependencies: Record<string, Package> };
+
 /**
  * Attempts to retrieve package data from the npm registry and return it
  */
 export const getPackage: RequestHandler = async function (req, res, next) {
   const { name, version } = req.params;
-
+  const dependencyTree = {};
   try {
     const npmPackage: NPMPackage = await got(
       `https://registry.npmjs.org/${name}`,
     ).json();
 
-    const dependencies: Record<string, string> = {};
-    for (const [ name, range ] of Object.entries(
-      npmPackage.versions[version].dependencies ?? {},
-    )) {
-      const subPackage: NPMPackage = await got(
-        `https://registry.npmjs.org/${name}`,
-      ).json();
-
-      dependencies[name] =
-        maxSatisfying(Object.keys(subPackage.versions), range) ?? range;
+    const dependencies: Record<string, string> =
+      npmPackage.versions[version].dependencies ?? {};
+    for (const [name, range] of Object.entries(dependencies)) {
+      const subDep = await getDependencies(name, range);
+      dependencyTree[name] = subDep;
     }
 
-    return res.status(200).json({ name, version, dependencies });
+    return res
+      .status(200)
+      .json({ name, version, dependencies: dependencyTree });
   } catch (error) {
     return next(error);
   }
 };
+
+async function getDependencies(name: string, range: string): Promise<Package> {
+  const npmPackage: NPMPackage = await got(
+    `https://registry.npmjs.org/${name}`,
+  ).json();
+
+  const v = maxSatisfying(Object.keys(npmPackage.versions), range);
+  const dependencies: Record<string, Package> = {};
+
+  if (v) {
+    const newDeps = npmPackage.versions[v].dependencies;
+    for (const [name, range] of Object.entries(newDeps ?? {})) {
+      dependencies[name] = await getDependencies(name, range);
+    }
+  }
+
+  return { version: v ?? range, dependencies };
+}

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -38,9 +38,41 @@ describe('/package/:name/:version endpoint', () => {
     expect(json.name).toEqual(packageName);
     expect(json.version).toEqual(packageVersion);
     expect(json.dependencies).toEqual({
-      'loose-envify': '1.4.0',
-      'object-assign': '4.1.1',
-      'prop-types': '15.7.2',
+      'loose-envify': {
+        version: '1.4.0',
+        dependencies: {
+          'js-tokens': {
+            version: '4.0.0',
+            dependencies: {},
+          },
+        },
+      },
+      'object-assign': {
+        version: '4.1.1',
+        dependencies: {},
+      },
+      'prop-types': {
+        version: '15.7.2',
+        dependencies: {
+          'object-assign': {
+            version: '4.1.1',
+            dependencies: {},
+          },
+          'loose-envify': {
+            version: '1.4.0',
+            dependencies: {
+              'js-tokens': {
+                version: '4.0.0',
+                dependencies: {},
+              },
+            },
+          },
+          'react-is': {
+            version: '16.13.1',
+            dependencies: {},
+          },
+        },
+      },
     });
   });
 });


### PR DESCRIPTION
In order to extend our vulnerability scanning feature to support child dependencies for [npm packages](https://docs.npmjs.com/cli/v6/configuring-npm/package-json) as described in #5  , this pull request updates the package service to return all nested dependencies on the internal /package endpoint for consumption by vulnerability service instead of just returning the versions for the first level.

It supports a `GET` request to the `/package/:name/:version` endpoint and will return a JSON structure representing the full tree of dependencies. We will always return the latest matching version of a package supported to mimic the behavior of a fresh `npm install`.

**Testing**

It can be tested locally by making a request for a package with sub-dependencies e.g. `react@16.13.0`

    curl -s http://localhost:3000/package/react/16.13.0 | jq .

**Related Ticket**

* #5 
