### PR TITLE
Adds transitive dependencies (Python)

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -3,10 +3,15 @@ from typing import Optional
 from pydantic import BaseModel
 
 
+class Package(BaseModel):
+    version: str
+    dependencies: dict[str, dict]
+
+
 class NPMPackageVersion(BaseModel):
     name: str
     version: str
-    dependencies: Optional[dict[str, str]] = None
+    dependencies: Optional[dict[str, str]] = {}
 
 
 class NPMPackage(BaseModel):
@@ -14,3 +19,6 @@ class NPMPackage(BaseModel):
     description: str
     dist_tags: dict[str, str]
     versions: dict[str, NPMPackageVersion]
+
+
+Package.update_forward_refs()

--- a/src/package.py
+++ b/src/package.py
@@ -3,12 +3,12 @@ from typing import Optional
 import requests
 from semver import max_satisfying
 
-from src.models import NPMPackage, NPMPackageVersion
+from src.models import NPMPackage, Package
 
 NPM_REGISTRY_URL = "https://registry.npmjs.org"
 
 
-async def get_package(name: str, version: Optional[str] = None) -> NPMPackageVersion:
+async def get_package(name: str, version: Optional[str] = None) -> dict:
     url = f"{NPM_REGISTRY_URL}/{name}"
     npm_package = requests.get(url).json()
     package = NPMPackage(
@@ -21,4 +21,31 @@ async def get_package(name: str, version: Optional[str] = None) -> NPMPackageVer
         version = max_satisfying(package.versions.keys(), "*")
 
     dependencies = package.versions[version].dependencies
-    return NPMPackageVersion(name=name, version=version, dependencies=dependencies)
+    dependency_tree = {
+        dependency_name: await get_dependencies(dependency_name, dependency_range)
+        for dependency_name, dependency_range in dependencies.items()
+    }
+    return {"name": name, "version": version, "dependencies": dependency_tree}
+
+
+async def get_dependencies(name: str, range: str) -> Package:
+    url = f"{NPM_REGISTRY_URL}/{name}"
+    npm_package = requests.get(url).json()
+    package = NPMPackage(
+        name=npm_package["name"],
+        description=npm_package["description"],
+        dist_tags=npm_package["dist-tags"],
+        versions=npm_package["versions"],
+    )
+
+    dependencies = {}
+
+    version = max_satisfying(package.versions.keys(), range)
+    if version:
+        new_dependencies = package.versions[version].dependencies
+        dependencies = {
+            dependency_name: await get_dependencies(dependency_name, dependency_range)
+            for dependency_name, dependency_range in new_dependencies.items()
+        }
+
+    return Package(version=version or range, dependencies=dependencies)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -6,10 +6,27 @@ from src.app import app
 def test_get_package():
     client = TestClient(app)
 
-    response = client.get("/package/express/2.0.0")
+    response = client.get("/package/react/16.13.0")
     assert response.status_code == 200
     assert response.json() == {
-        "dependencies": {"connect": ">= 1.1.0 < 2.0.0", "mime": ">= 0.0.1", "qs": ">= 0.0.6"},
-        "name": "express",
-        "version": "2.0.0",
+        "dependencies": {
+            "loose-envify": {
+                "dependencies": {"js-tokens": {"dependencies": {}, "version": "4.0.0"}},
+                "version": "1.4.0",
+            },
+            "object-assign": {"dependencies": {}, "version": "4.1.1"},
+            "prop-types": {
+                "dependencies": {
+                    "loose-envify": {
+                        "dependencies": {"js-tokens": {"dependencies": {}, "version": "4.0.0"}},
+                        "version": "1.4.0",
+                    },
+                    "object-assign": {"dependencies": {}, "version": "4.1.1"},
+                    "react-is": {"dependencies": {}, "version": "16.13.1"},
+                },
+                "version": "15.7.2",
+            },
+        },
+        "name": "react",
+        "version": "16.13.0",
     }


### PR DESCRIPTION
In order to extend our vulnerability scanning feature to support child dependencies for [npm packages](https://docs.npmjs.com/cli/v6/configuring-npm/package-json) as described in #5  , this pull request updates the package service to return all nested dependencies on the internal `/package` endpoint for consumption by vulnerability service instead of just returning the versions for the first level.

It supports a `GET` request to the `/package/:name/:version` endpoint and will return a JSON structure representing the full tree of dependencies. We will always return the latest matching version of a package supported to mimic the behavior of a fresh `npm install`.

**Testing**

It can be tested locally by making a request for a package with sub-dependencies e.g. `react@16.13.0`

    curl -s http://localhost:3000/package/react/16.13.0 | jq .

**Related Ticket**

* #5 
