### PR TITLE
Adds transitive dependencies (.NET)

### DIFF
--- a/Snyk.Exercise.WebApi/Controllers/PackageController.cs
+++ b/Snyk.Exercise.WebApi/Controllers/PackageController.cs
@@ -1,7 +1,9 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using SemanticVersioning;
 
 namespace Snyk.Exercise.WebApi.Controllers
 {
@@ -17,6 +19,8 @@ namespace Snyk.Exercise.WebApi.Controllers
         [Route("{name}/{version}")]
         public async Task<PackageDependencies> Get(string name, string version)
         {
+            var dependencyTree = new Dictionary<string, dynamic>();
+
             using var httpClient = new HttpClient();
             var response = await httpClient.GetAsync($"https://registry.npmjs.org/{name}");
             response.EnsureSuccessStatusCode();
@@ -27,12 +31,61 @@ namespace Snyk.Exercise.WebApi.Controllers
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             });
 
+            var dependencies = npmPackage.Versions[version].Dependencies;
+
+            foreach (var dep in dependencies) {
+                var subDep = GetDependencies(dep.Key, dep.Value).Result;
+                dependencyTree.Add(dep.Key, new
+                {
+                    Version = dep.Value,
+                    Dependecies = subDep
+                });
+            }
+
             return new PackageDependencies
             {
                 Name = name,
                 Version = version,
-                Dependencies = npmPackage.Versions[version].Dependencies,
+                Dependencies = dependencyTree,
             };
+        }
+
+        public async Task<Dictionary<string, dynamic>> GetDependencies(string name, string version)
+        {
+            using var httpClient = new HttpClient();
+            var response = await httpClient.GetAsync($"https://registry.npmjs.org/{name}");
+            response.EnsureSuccessStatusCode();
+            var jsonString = await response.Content.ReadAsStringAsync();
+            var npmPackage = JsonSerializer.Deserialize<NpmPackage>(jsonString, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            });
+
+            var range = new Range(version);
+            var v = range.MaxSatisfying(npmPackage.Versions.Keys);
+
+            if (!string.IsNullOrEmpty(v))
+            {
+                var dependencyTree = new Dictionary<string, dynamic>();
+                var newDeps = npmPackage.Versions[v].Dependencies;
+                if (newDeps != null) {
+                    foreach (var dep in newDeps)
+                    {
+                        var subDep = GetDependencies(dep.Key, dep.Value).Result;
+                        dependencyTree.Add(dep.Key, new
+                        {
+                            Version = dep.Value,
+                            Dependecies = subDep
+                        });
+                    }
+                }
+
+                return dependencyTree;
+            }
+            else
+            {
+                return null;
+            }
         }
     }
 }

--- a/Snyk.Exercise.WebApi/PackageDependencies.cs
+++ b/Snyk.Exercise.WebApi/PackageDependencies.cs
@@ -6,5 +6,5 @@ public class PackageDependencies
 
     public string Version { get; set; }
 
-    public Dictionary<string, string> Dependencies { get; set; }
+    public Dictionary<string, dynamic> Dependencies { get; set; }
 }

--- a/Snyk.Exercise.WebApi/Snyk.Exercise.WebApi.csproj
+++ b/Snyk.Exercise.WebApi/Snyk.Exercise.WebApi.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SemanticVersioning" Version="2.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
   </ItemGroup>
 


### PR DESCRIPTION
In order to extend our vulnerability scanning feature to support child dependencies for [npm packages](https://docs.npmjs.com/cli/v6/configuring-npm/package-json) as described in #5 , this pull request updates the package service to return all nested dependencies on the internal /package endpoint for consumption by vulnerability service instead of just returning the versions for the first level.

It supports a `GET` request to the `/package/:name/:version` endpoint and will return a JSON structure representing the full tree of dependencies. We will always return the latest matching version of a package supported to mimic the behavior of a fresh `npm install`.

**Testing**

It can be tested locally by making a request for a package with sub-dependencies e.g. `react@16.13.0`

    curl -s -k http://localhost:5001/package/react/16.13.0 | jq .

**Related Ticket**

* #5