### PR TITLE
fix: Update pre-commit hooks and migrate config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
 jobs:
   test:
     executor: python311
-    resource_class: 'small'
+    resource_class: "small"
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
@@ -23,7 +23,7 @@ jobs:
             poetry run pytest
   lint:
     executor: python311
-    resource_class: 'small'
+    resource_class: "small"
     steps:
       - run:
           name: Install pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 ---
-default_stages: ["commit"]
+default_stages: ["pre-commit"]
 exclude: templates/
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.4.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
         args: ["--py311-plus"]
   - repo: https://github.com/PyCQA/autoflake
-    rev: v2.1.1
+    rev: v2.3.1
     hooks:
       - id: autoflake
         args:
@@ -18,28 +18,28 @@ repos:
             "--remove-unused-variable",
           ]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
   - repo: https://github.com/ambv/black
-    rev: 23.3.0
+    rev: 24.10.0
     hooks:
       - id: black
         exclude: migrations
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8
         exclude: migrations
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.13.0
     hooks:
       - id: mypy
         exclude: ^(migrations/|scripts/|tests/)
         additional_dependencies:
           [types-pytz, types-requests, types-redis, types-dateparser]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-ast
       - id: check-case-conflict
@@ -57,19 +57,19 @@ repos:
       - id: trailing-whitespace
         exclude: __snapshots__
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.32.0
+    rev: v1.35.1
     hooks:
       - id: yamllint
         args: ["--strict"]
   # FIXME: this only run locally, I could't
   # find a way to enforce it on CircleCI
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: 3.2.2
+    rev: v3.30.1
     hooks:
       - id: commitizen
         stages: [commit-msg]
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.9-for-vscode
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         additional_dependencies:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ tree of a [npm](https://npmjs.org) package.
 
 ## Prerequisites
 
-* [Python 3.11](https://www.python.org/downloads/release/python-3116/)
+- [Python 3.11](https://www.python.org/downloads/release/python-3116/)
 
 ## Getting Started
 

--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -18,5 +18,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/packages/admin.py
+++ b/packages/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/packages/apps.py
+++ b/packages/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class PackagesConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'packages'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "packages"

--- a/packages/tests.py
+++ b/packages/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/project/asgi.py
+++ b/project/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
 
 application = get_asgi_application()

--- a/project/wsgi.py
+++ b/project/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
 
 application = get_wsgi_application()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -9,5 +9,5 @@ def test_get_package():
         "dependencies": {"connect": ">= 1.1.0 < 2.0.0", "mime": ">= 0.0.1", "qs": ">= 0.0.6"},
         "name": "express",
         "version": "2.0.0",
-        'description': 'Sinatra inspired web development framework',
+        "description": "Sinatra inspired web development framework",
     }


### PR DESCRIPTION
This PR addresses the following error when attempting to run pre-commit, using the old hooks, against the branch `python-1.0`:

```console
$ pre-commit run -a
[WARNING] top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[INFO] Initializing environment for https://github.com/commitizen-tools/commitizen.
An unexpected error has occurred: CalledProcessError: command: ('/home/patrick/.nix-profile/bin/git', 'checkout', '3.2.2')
return code: 1
stdout: (none)
stderr:
    error: pathspec '3.2.2' did not match any file(s) known to git
Check the log at /home/patrick/.cache/pre-commit/pre-commit.log
```

The following two steps have been applied to this PR:
- Update hooks & migrate config to pre-commit >= 4: `pre-commit autoupdate`
- Run updated hooks against branch: `pre-commit run -a`