### PR TITLE
feat: added transitive dependencies

### DIFF
--- a/src/model.cc
+++ b/src/model.cc
@@ -5,7 +5,6 @@ namespace model {
     j = nlohmann::json{
       {"name", vp.name_},
       {"version", vp.version_},
-      {"description", vp.description_},
       {"dependencies", vp.dependencies_}
     };
   }

--- a/src/model.h
+++ b/src/model.h
@@ -10,13 +10,14 @@ namespace model{
       VersionedPackage(const std::string& name,
                       const std::string& version,
                       const std::string& description,
-                      const std::vector<std::pair<std::string, std::string>>& dependencies)
+                      const std::vector<VersionedPackage>& dependencies)
           : name_(name), version_(version), description_(description), dependencies_(dependencies) {}
 
       const std::string& get_name() const { return name_; }
       const std::string& get_version() const { return version_; }
       const std::string& get_description() const { return description_; }
-      const std::vector<std::pair<std::string, std::string>>& get_dependencies() const { return dependencies_; }
+      const std::vector<VersionedPackage>& get_dependencies() const { return dependencies_; }
+      const void add_dependency(const VersionedPackage vp) { dependencies_.push_back(vp); }
 
       friend void to_json(nlohmann::json& j, const VersionedPackage& vp);
 
@@ -24,7 +25,7 @@ namespace model{
       std::string name_;
       std::string version_;
       std::string description_;
-      std::vector<std::pair<std::string, std::string>> dependencies_;
+      std::vector<VersionedPackage> dependencies_;
   };
 
   void to_json(nlohmann::json& j, const VersionedPackage& vp);

--- a/src/npm.cc
+++ b/src/npm.cc
@@ -11,24 +11,31 @@ namespace npm {
     constexpr std::string_view NPM_REGISTRY_URL = "https://registry.npmjs.org";
   }
 
-  VersionedPackage get_versioned_package(const std::string& name, const std::string& version) {
-    std::string url = std::string(NPM_REGISTRY_URL) + "/" + name + "/" + version;
+  VersionedPackage get_versioned_package(const std::string& name, const std::string& range) {
+    std::string url = std::string(NPM_REGISTRY_URL) + "/" + name;
 
     std::ostringstream response_stream;
     nlohmann::json npm_package = nlohmann::json::parse(util::curl_request(url, &response_stream));
     response_stream.clear();
 
-    std::vector<std::pair<std::string, std::string>> dependencies;
-    for (const auto& dep : npm_package["dependencies"].items()) {
-        dependencies.emplace_back(dep.key(), dep.value());
+    std::vector<std::string> versions;
+    for (auto it = npm_package["versions"].begin(); it != npm_package["versions"].end(); ++it) {
+        versions.push_back(it.key());
     }
+    std::string version = util::max_satisfying(versions, range);
+    const nlohmann::json& version_record = npm_package["versions"][version];
+    const nlohmann::json& dependencies = version_record.value("dependencies", nlohmann::json::object());
 
     VersionedPackage package{
-        npm_package["name"],
-        npm_package["version"],
-        npm_package["description"],
-        std::move(dependencies)
+        version_record["name"],
+        version_record["version"],
+        version_record["description"],
+        {}
     };
+
+    for (const auto& dep : dependencies.items()) {
+        package.add_dependency(get_versioned_package(dep.key(), dep.value()));
+    }
 
     return package;
   }

--- a/src/npm.h
+++ b/src/npm.h
@@ -3,5 +3,5 @@
 #include "model.h"
 
 namespace npm {
-  model::VersionedPackage get_versioned_package(const std::string& name, const std::string& version);
+  model::VersionedPackage get_versioned_package(const std::string& name, const std::string& range);
 }

--- a/tests/test_versioned_package.cc
+++ b/tests/test_versioned_package.cc
@@ -8,7 +8,7 @@ using model::VersionedPackage;
 
 TEST(VersionedPackageTest, TestGetVersionedPackage) {
     // Define an instance of VersionedPackage
-    VersionedPackage package = npm::get_versioned_package("express", "2.0.0");
+    VersionedPackage package = npm::get_versioned_package("minimatch", "3.1.2");
 
     // Serialize the instance to JSON
     json generated_json;
@@ -16,13 +16,17 @@ TEST(VersionedPackageTest, TestGetVersionedPackage) {
 
     std::string expected_json_str = R"({
         "dependencies": [
-          ["connect", ">= 1.1.0 < 2.0.0"],
-          ["mime", ">= 0.0.1"], 
-          ["qs", ">= 0.0.6"]
+          {
+            "dependencies": [
+              {"dependencies": [], "name": "balanced-match", "version": "1.0.2"},
+              {"dependencies": [], "name": "concat-map", "version": "0.0.1"}
+            ],
+            "name": "brace-expansion",
+            "version": "1.1.11"
+          }
         ],
-        "name": "express",
-        "version": "2.0.0",
-        "description": "Sinatra inspired web development framework"
+        "name": "minimatch",
+        "version": "3.1.2"
     })";
     json expected_json = json::parse(expected_json_str);
 


### PR DESCRIPTION
In order to extend our vulnerability scanning feature to support child dependencies for [npm packages](https://docs.npmjs.com/cli/v6/configuring-npm/package-json) as described in #5  , this pull request updates the package service to return all nested dependencies on the internal `/package` endpoint for consumption by vulnerability service instead of just returning the versions for the first level.

The binary support package name and range as dependencies and will return a JSON structure representing the full tree of dependencies. We will always return the latest matching version of a package supported to mimic the behavior of a fresh `npm install`.

**Testing**

It can be tested locally by making a request for a package with sub-dependencies e.g. `react@16.13.0`

    curl -s http://localhost:3000/package/react/16.13.0 | jq .

**Related Ticket**

* #5 
